### PR TITLE
Add nft-bam v0.1.1

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -24,5 +24,8 @@
   "releases": [{
     "version": "0.1.0",
     "url": "https://github.com/nvnieuwk/nft-bam/releases/download/0.1.0/nft-bam-0.1.0.jar"
+  },{
+    "version": "0.1.1",
+    "url": "https://github.com/nvnieuwk/nft-bam/releases/download/0.1.1/nft-bam-0.1.1.jar"
   }]
 }]


### PR DESCRIPTION
This version contains a fix for this error (hopefully)

```
java.lang.UnsupportedClassVersionError: htsjdk/samtools/SamReaderFactory has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```

@lukfor could you merge this in when you have some time, thank you!