### PR TITLE
Add simple download counter from github releases

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,6 +23,38 @@
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 
+  <style>
+    .hero-header {
+        background-color: #009485;
+        color: white;
+        padding: 20px 20px;
+        width: 100%;
+        text-align: center;
+    }
+
+    .hero-header .container {
+        margin-top: 0;
+    }
+
+    .hero-header h1,
+    .hero-header p {
+        margin: 0;
+    }
+
+    .btn-install {
+      background-color: #009485;
+        color: white;
+    }
+    a {
+      color: #009485;
+    }
+
+    .card-footer {
+      background-color: #ffffff;
+    }
+
+  </style>
+
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -5,27 +5,32 @@
 layout: default
 ---
 
+<div class="hero-header">
+    <div class="container mt-5">
+        <h1 class="mb-4">Plugins</h1>
+        <p>Explore nf-test plugins made by the community.</p>
+    </div>
+</div>
 
 
 <div class="container mt-5">
-
-    <h1 lass="mb-4">Plugins</h1>
-
-    <p>Explore nf-test plugins made by the community.</p>
-
-    <hr>
 
     <div class="row">
         {% for plugin in site.data.plugins %}
         <div class="col-md-4 mb-4">
             <div class="card">
                 <div class="card-body" style="height: 200px;">
-                    <h5 class="card-title"><a href="{{plugin.url}}">{{plugin.id}}</a> {{plugin.latest}}</h5>
+                    <h5 class="card-title"><a href="{{plugin.url}}" target = "_blank">{{plugin.id}}</a> {{plugin.latest}}</h5>
                     <h6 class="card-subtitle mb-2 text-muted">by {{plugin.author}}</h6>
                     <p>{{plugin.description}}</p>
                 </div>
-                <div class="card-footer">
-                    <button data-plugin="{{plugin.id}}@{{plugin.latest}}"class="btn-install btn btn-secondary btn-sm">Install</button>
+                <div class="card-footer d-flex align-items-center justify-content-between">
+                    <button data-plugin="{{plugin.id}}@{{plugin.latest}}"class="btn-install btn btn-secondary btn-sm">
+                        Install
+                    </button>
+                    <a href="https://github.com/{{plugin.github}}" target="_blank">
+                        <img src = "https://img.shields.io/github/downloads/{{plugin.github}}/total?labelColor=%23ffffff" class="float-right">
+                    </a>
                 </div>
             </div>
         </div>

--- a/plugins.json
+++ b/plugins.json
@@ -2,28 +2,31 @@
   "id": "nft-fasta",
   "latest": "1.0.0",
   "url": "https://github.com/askimed/nft-fasta",
+  "github": "askimed/nft-fasta",
   "description": "Provides support for FASTA files.",
   "author": "Lukas Forer",
   "keywords": [],
   "releases": [{
     "version": "1.0.0",
-    "url": "https://github.com/askimed/nft-fasta/releases/download/v1.0.0/nft-fasta-1.0.0.jar",
+    "url": "https://github.com/askimed/nft-fasta/releases/download/v1.0.0/nft-fasta-1.0.0.jar"
   }]
 },{
   "id": "nft-vcf",
   "latest": "1.0.2",
   "url": "https://github.com/seppinho/nft-vcf",
+  "github": "seppinho/nft-vcf",
   "description": "Provides support for VCF files.",
   "author": "Sebastian Schönherr",
   "keywords": [],
   "releases": [{
     "version": "1.0.2",
-    "url": "https://github.com/seppinho/nft-vcf/releases/download/v1.0.2/nft-vcf-1.0.2-jar-with-dependencies.jar",
+    "url": "https://github.com/seppinho/nft-vcf/releases/download/v1.0.2/nft-vcf-1.0.2-jar-with-dependencies.jar"
   }]
 },{
   "id": "nft-bam",
   "latest": "0.1.1",
-  "url": "https://github.com/nvnieuwk/nft-bam",
+  "url": "https://nvnieuwk.github.io/nft-bam",
+  "github": "nvnieuwk/nft-bam",
   "description": "Provides some helper functionality for handling SAM/BAM/CRAM files during tests",
   "author": "Nicolas Vannieuwkerke",
   "keywords": [],


### PR DESCRIPTION
Adds a simple download counter using https://shields.io/badges/git-hub-downloads-all-assets-all-releases

@nvnieuwk,  could you please double-check before I destroy nf-core again? ;)


![Screenshot 2024-06-06 at 12 24 02](https://github.com/askimed/nf-test-plugins/assets/210220/e61cb2ce-2d79-4736-b1f7-35c7d5201a1f)
