### PR TITLE
Add nft-anndata plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -115,5 +115,17 @@
     "version": "0.0.1",
     "url": "https://github.com/lukfor/nft-fastq/releases/download/v0.0.1/nft-fastq-0.0.1-all.jar"
   }]
+}, {
+  "id": "nft-anndata",
+  "latest": "0.1.0",
+  "url": "https://github.com/nictru/nft-anndata",
+  "github": "nictru/nft-anndata",
+  "description": "Provides support for AnnData (h5ad) files.",
+  "author": "Nico Trummer",
+  "keywords": [],
+  "releases": [{
+    "version": "0.1.0",
+    "url": "https://github.com/nictru/nft-anndata/releases/download/v0.1.0/nft-anndata-0.1.0.jar"
+  }]
 }
 ]


### PR DESCRIPTION
This plugin adds support for the AnnData format, which is a binary matrix format based on `h5`. It is mostly used for storing single-cell count data as part of the scverse/scanpy ecosystem. The pipelines nf-core/scrnaseq and nf-core/scdownstream will use this plugin to improve testing.