### PR TITLE
Add nft-tiff plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -130,5 +130,17 @@
     "version": "0.1.0",
     "url": "https://github.com/nictru/nft-anndata/releases/download/v0.1.0/nft-anndata-0.1.0.jar"
   }]
+}, {
+  "id": "nft-tiff",
+  "latest": "0.1.0",
+  "url": "https://github.com/nf-core/nft-tiff",
+  "github": "nf-core/nft-tiff",
+  "description": "Provides support for TIFF files.",
+  "author": "nf-core",
+  "keywords": [],
+  "releases": [{
+    "version": "0.1.0",
+    "url": "https://github.com/nf-core/nft-tiff/releases/download/v0.1.0/nft-tiff-0.1.0.jar"
+  }]
 }
 ]


### PR DESCRIPTION
This plugin adds support for TIFF raster image files. These files are common in Earth Observation research, where they primarily store satellite data.  Biological imaging also uses TIFF imagery. The [nf-core/rangeland](https://github.com/nf-core/rangeland) pipeline will use this plugin to improve testing. In addition, this plugin enables new Earth Observation nf-core modules. 