### PR TITLE
Add nft-utils 1.0.0 release

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -120,7 +120,7 @@
   },
   {
     "id": "nft-utils",
-    "latest": "0.0.9",
+    "latest": "1.0.0",
     "url": "https://github.com/nf-core/nft-utils",
     "github": "nf-core/nft-utils",
     "description": "nf-test utility functions for Nextflow pipelines.",
@@ -162,6 +162,10 @@
       {
         "version": "0.0.9",
         "url": "https://github.com/nf-core/nft-utils/releases/download/0.0.9/nft-utils-0.0.9.jar"
+      },
+      {
+        "version": "1.0.0",
+        "url": "https://github.com/nf-core/nft-utils/releases/download/1.0.0/nft-utils-1.0.0.jar"
       }
     ]
   },


### PR DESCRIPTION
Updates `nft-utils` to version 1.0.0:
- Sets `latest` to `1.0.0`
- Adds the 1.0.0 release entry

To be merged once https://github.com/nf-core/nft-utils/pull/71 is merged and the release done