### PR TITLE
Add nft-anndata 0.5.0 and 0.5.1 releases

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -190,12 +190,12 @@
   },
   {
     "id": "nft-anndata",
-    "latest": "0.4.1",
+    "latest": "0.5.0",
     "url": "https://github.com/nictru/nft-anndata",
     "github": "nictru/nft-anndata",
-    "description": "Provides support for AnnData (h5ad) files.",
+    "description": "Provides support for AnnData (.h5ad and .zarr) files.",
     "author": "Nico Trummer",
-    "keywords": ["anndata", "h5ad"],
+    "keywords": ["anndata", "h5ad", "zarr"],
     "releases": [
       {
         "version": "0.1.0",
@@ -220,6 +220,10 @@
       {
         "version": "0.4.1",
         "url": "https://github.com/nictru/nft-anndata/releases/download/v0.4.1/nft-anndata-0.4.1.jar"
+      },
+      {
+        "version": "0.5.0",
+        "url": "https://github.com/nictru/nft-anndata/releases/download/v0.5.0/nft-anndata-0.5.0.jar"
       }
     ]
   },

--- a/plugins.json
+++ b/plugins.json
@@ -190,7 +190,7 @@
   },
   {
     "id": "nft-anndata",
-    "latest": "0.5.0",
+    "latest": "0.5.1",
     "url": "https://github.com/nictru/nft-anndata",
     "github": "nictru/nft-anndata",
     "description": "Provides support for AnnData (.h5ad and .zarr) files.",
@@ -224,6 +224,10 @@
       {
         "version": "0.5.0",
         "url": "https://github.com/nictru/nft-anndata/releases/download/v0.5.0/nft-anndata-0.5.0.jar"
+      },
+      {
+        "version": "0.5.1",
+        "url": "https://github.com/nictru/nft-anndata/releases/download/v0.5.1/nft-anndata-0.5.1.jar"
       }
     ]
   },


### PR DESCRIPTION
Adds nft-anndata to the plugin registry with releases 0.5.0 (Zarr support) and 0.5.1 (remote h5ad staging classloader fix). Latest is set to 0.5.1.